### PR TITLE
This PR proposes a new method for getting joint names from CoppeliaSim

### DIFF
--- a/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ.m
+++ b/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ.m
@@ -436,6 +436,45 @@ classdef DQ_CoppeliaSimInterfaceZMQ < DQ_CoppeliaSimInterface
             obj.sim_.setJointTargetForce(obj.get_handle_from_map_(jointname), force, true);
         end
 
+        function objectname = get_object_name_(obj, handle)
+            % This method gets the name of an object in the CoppeliaSim scene.
+            %
+            % Usage: objectname = get_object_name_(handle)
+            %
+            %         handle: The object handle.
+            %
+            % Example:
+            %      objectname = get_object_name_(handle)
+           arguments 
+                obj (1,1) DQ_CoppeliaSimInterfaceZMQ
+                handle (1,1) {mustBeNumeric}
+           end
+           obj.check_client_();
+           objectname = obj.sim_.getObjectAlias(handle, 1);
+           obj.update_map_(objectname, handle);
+        end
+
+        function objectnames = get_object_names_(obj, handles)
+            % This method gets the object names in the CoppeliaSim scene.
+            %
+            % Usage: objectnames = get_object_names_(handles)
+            %
+            %         handles: The object handles.
+            %
+            % Example:
+            %      objectnames = get_object_names_(handles)
+            arguments 
+                 obj (1,1) DQ_CoppeliaSimInterfaceZMQ
+                 handles cell
+            end
+            n = length(handles);
+            objectnames = cell(1,n);
+            for i=1:n
+                objectnames{i}=obj.get_object_name_(handles{i});
+            end
+        end
+
+
     end
 
     methods
@@ -972,44 +1011,6 @@ classdef DQ_CoppeliaSimInterfaceZMQ < DQ_CoppeliaSimInterface
     % Exclusive ZMQ methods, which are not enforced by the
     % DQ_CoppeliaSimInterface class
     methods 
-        function objectname = get_object_name(obj, handle)
-            % This method gets the name of an object in the CoppeliaSim scene.
-            %
-            % Usage: objectname = get_object_name(handle)
-            %
-            %         handle: The object handle.
-            %
-            % Example:
-            %      objectname = get_object_name(handle)
-           arguments 
-                obj (1,1) DQ_CoppeliaSimInterfaceZMQ
-                handle (1,1) {mustBeNumeric}
-           end
-           obj.check_client_();
-           objectname = obj.sim_.getObjectAlias(handle, 1);
-           obj.update_map_(objectname, handle);
-        end
-
-        function objectnames = get_object_names(obj, handles)
-            % This method gets the object names in the CoppeliaSim scene.
-            %
-            % Usage: objectnames = get_object_name(handles)
-            %
-            %         handles: The object handles.
-            %
-            % Example:
-            %      objectnames = get_object_names(handles)
-            arguments 
-                 obj (1,1) DQ_CoppeliaSimInterfaceZMQ
-                 handles cell
-            end
-            n = length(handles);
-            objectnames = cell(1,n);
-            for i=1:n
-                objectnames{i}=obj.get_object_name(handles{i});
-            end
-        end
-
         function jointnames =  get_jointnames_from_object(obj, objectname)
             % This method gets all the names of the joints under the hierarchy tree, 
             % in which the object name describes its base.
@@ -1028,7 +1029,7 @@ classdef DQ_CoppeliaSimInterfaceZMQ < DQ_CoppeliaSimInterface
            base_handle = obj.get_handle_from_map_(objectname);
            jointhandles = obj.sim_.getObjectsInTree(base_handle,...
                                                 obj.sim_.object_joint_type,0);
-           jointnames = obj.get_object_names(jointhandles);
+           jointnames = obj.get_object_names_(jointhandles);
         end
     end
 

--- a/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ.m
+++ b/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ.m
@@ -969,6 +969,69 @@ classdef DQ_CoppeliaSimInterfaceZMQ < DQ_CoppeliaSimInterface
 
     end
 
+    % Exclusive ZMQ methods, which are not enforced by the
+    % DQ_CoppeliaSimInterface class
+    methods 
+        function objectname = get_object_name(obj, handle)
+            % This method gets the name of an object in the CoppeliaSim scene.
+            %
+            % Usage: objectname = get_object_name(handle)
+            %
+            %         handle: The object handle.
+            %
+            % Example:
+            %      objectname = get_object_name(handle)
+           arguments 
+                obj (1,1) DQ_CoppeliaSimInterfaceZMQ
+                handle (1,1) {mustBeNumeric}
+           end
+           obj.check_client_();
+           objectname = obj.sim_.getObjectAlias(handle, 1);
+           obj.update_map_(objectname, handle);
+        end
+
+        function objectnames = get_object_names(obj, handles)
+            % This method gets the object names in the CoppeliaSim scene.
+            %
+            % Usage: objectnames = get_object_name(handles)
+            %
+            %         handles: The object handles.
+            %
+            % Example:
+            %      objectnames = get_object_names(handles)
+           arguments 
+                obj (1,1) DQ_CoppeliaSimInterfaceZMQ
+                handles cell
+           end
+           n = length(handles);
+           objectnames = cell(1,n);
+           for i=1:n
+               objectnames{i}=obj.get_object_name(handles{i});
+           end
+        end
+
+        function jointnames =  get_jointnames_from_object(obj, objectname)
+            % This method gets all the names of the joints under the hierarchy tree, 
+            % in which the object name describes its base.
+            %
+            % Usage: jointnames = get_jointnames_from_object(objectname);
+            %
+            %         objectname: The parent object name of the joints.
+            %
+            % Example:
+            %      jointnames = get_jointnames_from_object('LBR4p');
+           arguments 
+                obj (1,1) DQ_CoppeliaSimInterfaceZMQ
+                objectname (1,:) {mustBeText} 
+           end
+           obj.check_client_();
+           base_handle = obj.get_handle_from_map_(objectname);
+           jointhandles = obj.sim_.getObjectsInTree(base_handle,...
+                                                obj.sim_.object_joint_type,0);
+           jointnames = obj.get_object_names(jointhandles);
+        end
+    end
+
     methods % Deprecated methods to ensure backwards compatibility
         function disconnect_all(~)
             warning("The method disconnect_all is deprecated and is not required with ZeroMQ remote API.");

--- a/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ.m
+++ b/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ.m
@@ -999,15 +999,15 @@ classdef DQ_CoppeliaSimInterfaceZMQ < DQ_CoppeliaSimInterface
             %
             % Example:
             %      objectnames = get_object_names(handles)
-           arguments 
-                obj (1,1) DQ_CoppeliaSimInterfaceZMQ
-                handles cell
-           end
-           n = length(handles);
-           objectnames = cell(1,n);
-           for i=1:n
-               objectnames{i}=obj.get_object_name(handles{i});
-           end
+            arguments 
+                 obj (1,1) DQ_CoppeliaSimInterfaceZMQ
+                 handles cell
+            end
+            n = length(handles);
+            objectnames = cell(1,n);
+            for i=1:n
+                objectnames{i}=obj.get_object_name(handles{i});
+            end
         end
 
         function jointnames =  get_jointnames_from_object(obj, objectname)


### PR DESCRIPTION
Hi @dqrobotics/developers,

This PR proposes a new method for getting joint names from CoppeliaSim. The method returns all joint names belonging to the hierarchy tree, whose base is a user-defined object. This method is the first step towards the new ongoing class `DQ_CoppeliaSimRobotZMQ`.

Specifically, this PR adds three new methods:

- [protected]  `get_object_name_`: to get the name of an object, given its handle.
- [protected]  `get_object_names_`: to get the object names given their handles.
- [public] `get_jointnames_from_object`: This method uses both new protected methods and returns the desired joint names.


### Motivation

In the (now deprecated) class [DQ_SerialVrepRobot.m](https://github.com/dqrobotics/matlab-interface-vrep/blob/main/interfaces/vrep/DQ_SerialVrepRobot.m), the joint names are defined in the constructor using the robot name and the joint index:

```matlab
            for i=1:robot_dof
                current_joint_name = {robot_label,'_joint',int2str(i),robot_index};
                obj.joint_names{i} = strjoin(current_joint_name,'');
            end
```

In this way, if we use the `LBR4p` robot, the `DQ_SerialVrepRobot` class creates the joint names as
```matlab
joint_names={'LBR4p_joint1','LBR4p_joint2',...
            'LBR4p_joint3','LBR4p_joint4',...
            'LBR4p_joint5','LBR4p_joint6',...
            'LBR4p_joint7'},
```
which used to work in previous versions of CoppeliaSim. However, in CoppeliaSim 4.7 (the current supported version by the DQ_CoppeliaSimInterfaceZMQ class), the joint names of the `LBR4p` robot are

```matlab
joint_names = {'/LBR4p/joint',...
              '/LBR4p/link/joint', ...
              '/LBR4p/link/joint/link/joint', ...
              '/LBR4p/link/joint/link/joint/link/joint', ...
              '/LBR4p/link/joint/link/joint/link/joint/link/joint', ...
              '/LBR4p/joint/link/joint/link/joint/link/joint/link/joint/link/joint',...
              '/LBR4p/joint/link/joint/link/joint/link/joint/link/joint/link/joint/link/joint'};
```
This new naming style for the joints could also change in future versions. Therefore, a method that returns the joint names automatically using the robot name without relying on a specific naming style could be useful. For instance, 

```matlab
cs = DQ_CoppeliaSimInterfaceZMQ();
cs.connect();
jointnames = cs.get_jointnames_from_object('LBR4p');
```

I proposed an example here https://github.com/dqrobotics/matlab-examples/pull/13

Please let me know what you think.

Kind regards, 



Juancho