### PR TITLE
This PR adds CoppeliaSim interface classes for serial robots

### DIFF
--- a/interfaces/coppeliasim/DQ_CoppeliaSimRobotZMQ.m
+++ b/interfaces/coppeliasim/DQ_CoppeliaSimRobotZMQ.m
@@ -22,18 +22,18 @@
 %    1. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
 %         - Responsible for the original implementation
 
-classdef DQ_SerialCoppeliaSimRobotZMQ < DQ_CoppeliaSimRobot
+classdef DQ_CoppeliaSimRobotZMQ < DQ_CoppeliaSimRobot
     properties (SetAccess = protected)
         base_frame_name_;
         joint_names_;
     end
 
     methods
-        function obj = DQ_SerialCoppeliaSimRobotZMQ(robot_name, coppeliasim_interface)
+        function obj = DQ_CoppeliaSimRobotZMQ(robot_name, coppeliasim_interface)
             % This method constructs an instance of a
-            % DQ_SerialCoppeliaSimRobotZMQ object.
+            % DQ_CoppeliaSimRobotZMQ object.
             % Usage:
-            %     DQ_SerialCoppeliaSimRobotZMQ(robot_name, coppeliasim_interface)
+            %     DQ_CoppeliaSimRobotZMQ(robot_name, coppeliasim_interface)
             %          robot_name: The name of the robot in the CoppeliaSim
             %          scene.
             %          coppeliasim_interface: The DQ_CoppeliaSimInterfaceZMQ
@@ -42,7 +42,7 @@ classdef DQ_SerialCoppeliaSimRobotZMQ < DQ_CoppeliaSimRobot
             % Example: 
             %      cs = DQ_CoppeliaSimInterfaceZMQ();
             %      cs.connect;
-            %      robot_coppeliasim = DQ_SerialCoppeliaSimRobotZMQ("/LBR4p", cs);
+            %      robot_coppeliasim = DQ_CoppeliaSimRobotZMQ("/LBR4p", cs);
             %     
             %    Note that the name of the robot should be EXACTLY the same
             %    as in CoppeliaSim. For instance, if you drag-and-drop a
@@ -77,7 +77,7 @@ classdef DQ_SerialCoppeliaSimRobotZMQ < DQ_CoppeliaSimRobot
             % Example: 
             %     cs = DQ_CoppeliaSimInterfaceZMQ();
             %     cs.connect;
-            %     robot_coppeliasim = DQ_SerialCoppeliaSimRobotZMQ("/LBR4p", cs);
+            %     robot_coppeliasim = DQ_CoppeliaSimRobotZMQ("/LBR4p", cs);
             %     q = zeros(7, 1);
             %     robot_coppeliasim.set_configuration(q);
             %     
@@ -86,7 +86,7 @@ classdef DQ_SerialCoppeliaSimRobotZMQ < DQ_CoppeliaSimRobot
             %     dynamics disabled scene.
 
             arguments 
-                obj (1,1) DQ_SerialCoppeliaSimRobotZMQ
+                obj (1,1) DQ_CoppeliaSimRobotZMQ
                 q (1,:) {mustBeNumeric}
             end
 
@@ -105,7 +105,7 @@ classdef DQ_SerialCoppeliaSimRobotZMQ < DQ_CoppeliaSimRobot
             % Example: 
             %     cs = DQ_CoppeliaSimInterfaceZMQ();
             %     cs.connect;
-            %     robot_coppeliasim = DQ_SerialCoppeliaSimRobotZMQ("/LBR4p", cs);
+            %     robot_coppeliasim = DQ_CoppeliaSimRobotZMQ("/LBR4p", cs);
             %     q = zeros(7, 1);
             %     robot_coppeliasim.set_target_configuration(q);
             %     
@@ -115,7 +115,7 @@ classdef DQ_SerialCoppeliaSimRobotZMQ < DQ_CoppeliaSimRobot
             %     mode with position control mode.
 
             arguments 
-                obj (1,1) DQ_SerialCoppeliaSimRobotZMQ
+                obj (1,1) DQ_CoppeliaSimRobotZMQ
                 q (1,:) {mustBeNumeric}
             end
 
@@ -132,11 +132,11 @@ classdef DQ_SerialCoppeliaSimRobotZMQ < DQ_CoppeliaSimRobot
             % Example: 
             %     cs = DQ_CoppeliaSimInterfaceZMQ();
             %     cs.connect;
-            %     robot_coppeliasim = DQ_SerialCoppeliaSimRobotZMQ("/LBR4p", cs);
+            %     robot_coppeliasim = DQ_CoppeliaSimRobotZMQ("/LBR4p", cs);
             %     q = robot_coppeliasim.get_configuration;
 
             arguments 
-                obj (1,1) DQ_SerialCoppeliaSimRobotZMQ
+                obj (1,1) DQ_CoppeliaSimRobotZMQ
             end
 
             q = obj.coppeliasim_interface_.get_joint_positions( ...
@@ -154,7 +154,7 @@ classdef DQ_SerialCoppeliaSimRobotZMQ < DQ_CoppeliaSimRobot
             % Example: 
             %     cs = DQ_CoppeliaSimInterfaceZMQ();
             %     cs.connect;
-            %     robot_coppeliasim = DQ_SerialCoppeliaSimRobotZMQ("/LBR4p", cs);
+            %     robot_coppeliasim = DQ_CoppeliaSimRobotZMQ("/LBR4p", cs);
             %     dq = zeros(7, 1);
             %     robot_coppeliasim.set_target_configuration_velocities(dq);
             %     
@@ -164,7 +164,7 @@ classdef DQ_SerialCoppeliaSimRobotZMQ < DQ_CoppeliaSimRobot
             %     mode with velocity control mode.
 
             arguments 
-                obj (1,1) DQ_SerialCoppeliaSimRobotZMQ
+                obj (1,1) DQ_CoppeliaSimRobotZMQ
                 dq (1,:) {mustBeNumeric}
             end
 
@@ -181,11 +181,11 @@ classdef DQ_SerialCoppeliaSimRobotZMQ < DQ_CoppeliaSimRobot
             % Example: 
             %     cs = DQ_CoppeliaSimInterfaceZMQ();
             %     cs.connect;
-            %     robot_coppeliasim = DQ_SerialCoppeliaSimRobotZMQ("/LBR4p", cs);
+            %     robot_coppeliasim = DQ_CoppeliaSimRobotZMQ("/LBR4p", cs);
             %     dq = robot_coppeliasim.get_configuration_velocities;
 
             arguments 
-                obj (1,1) DQ_SerialCoppeliaSimRobotZMQ
+                obj (1,1) DQ_CoppeliaSimRobotZMQ
             end
 
             dq = obj.coppeliasim_interface_.get_joint_velocities( ...
@@ -203,7 +203,7 @@ classdef DQ_SerialCoppeliaSimRobotZMQ < DQ_CoppeliaSimRobot
             % Example: 
             %     cs = DQ_CoppeliaSimInterfaceZMQ();
             %     cs.connect;
-            %     robot_coppeliasim = DQ_SerialCoppeliaSimRobotZMQ("/LBR4p", cs);
+            %     robot_coppeliasim = DQ_CoppeliaSimRobotZMQ("/LBR4p", cs);
             %     tau = zeros(7, 1);
             %     robot_coppeliasim.set_target_configuration_forces(tau);
             %     
@@ -213,7 +213,7 @@ classdef DQ_SerialCoppeliaSimRobotZMQ < DQ_CoppeliaSimRobot
             %     mode with force control mode.
 
             arguments 
-                obj (1,1) DQ_SerialCoppeliaSimRobotZMQ
+                obj (1,1) DQ_CoppeliaSimRobotZMQ
                 tau (1,:) {mustBeNumeric}
             end
 
@@ -230,11 +230,11 @@ classdef DQ_SerialCoppeliaSimRobotZMQ < DQ_CoppeliaSimRobot
             % Example: 
             %     cs = DQ_CoppeliaSimInterfaceZMQ();
             %     cs.connect;
-            %     robot_coppeliasim = DQ_SerialCoppeliaSimRobotZMQ("/LBR4p", cs);
+            %     robot_coppeliasim = DQ_CoppeliaSimRobotZMQ("/LBR4p", cs);
             %     tau = robot_coppeliasim.get_configuration_forces;
 
             arguments 
-                obj (1,1) DQ_SerialCoppeliaSimRobotZMQ
+                obj (1,1) DQ_CoppeliaSimRobotZMQ
             end
 
             tau = obj.coppeliasim_interface_.get_joint_forces( ...

--- a/interfaces/coppeliasim/DQ_SerialCoppeliaSimRobotZMQ.m
+++ b/interfaces/coppeliasim/DQ_SerialCoppeliaSimRobotZMQ.m
@@ -1,0 +1,244 @@
+% (C) Copyright 2011-2025 DQ Robotics Developers
+% 
+% This file is part of DQ Robotics.
+% 
+%     DQ Robotics is free software: you can redistribute it and/or modify
+%     it under the terms of the GNU Lesser General Public License as published by
+%     the Free Software Foundation, either version 3 of the License, or
+%     (at your option) any later version.
+% 
+%     DQ Robotics is distributed in the hope that it will be useful,
+%     but WITHOUT ANY WARRANTY; without even the implied warranty of
+%     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%     GNU Lesser General Public License for more details.
+% 
+%     You should have received a copy of the GNU Lesser General Public License
+%     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
+% 
+% DQ Robotics website: dqrobotics.github.io
+% 
+% Contributors:
+% 
+%    1. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
+%         - Responsible for the original implementation
+
+classdef DQ_SerialCoppeliaSimRobotZMQ < DQ_CoppeliaSimRobot
+    properties (SetAccess = protected)
+        base_frame_name_;
+        joint_names_;
+    end
+
+    methods
+        function obj = DQ_SerialCoppeliaSimRobotZMQ(robot_name, coppeliasim_interface)
+            % This method constructs an instance of a
+            % DQ_SerialCoppeliaSimRobotZMQ object.
+            % Usage:
+            %     DQ_SerialCoppeliaSimRobotZMQ(robot_name, coppeliasim_interface)
+            %          robot_name: The name of the robot in the CoppeliaSim
+            %          scene.
+            %          coppeliasim_interface: The DQ_CoppeliaSimInterfaceZMQ
+            %          object connected to the CoppeliaSim scene.
+            %
+            % Example: 
+            %      cs = DQ_CoppeliaSimInterfaceZMQ();
+            %      cs.connect;
+            %      robot_coppeliasim = DQ_SerialCoppeliaSimRobotZMQ("/LBR4p", cs);
+            %     
+            %    Note that the name of the robot should be EXACTLY the same
+            %    as in CoppeliaSim. For instance, if you drag-and-drop a
+            %    second robot to the scene, CoppeliaSim will rename the
+            %    first robot to "/LBR4p[0]" and name the second one
+            %    "/LBR4p[1]". A third robot will be named "/LBR4p[2]", and
+            %    so on.
+
+            arguments 
+                robot_name (1,:) {mustBeText}
+                coppeliasim_interface (1,1) DQ_CoppeliaSimInterfaceZMQ
+            end
+
+            obj@DQ_CoppeliaSimRobot;
+            obj.robot_name_ = robot_name;
+            obj.coppeliasim_interface_ = coppeliasim_interface;
+
+            obj.joint_names_ = ...
+                obj.coppeliasim_interface_.get_jointnames_from_object( ...
+                    robot_name);
+            obj.base_frame_name_ = obj.joint_names_{1};
+        end
+
+        function set_configuration(obj, q)
+            % This method sets the joint configurations of the robot in the
+            % CoppeliaSim scene.
+            % Usage:
+            %     set_configuration(q);  
+            %          q: The joint configurations for the robot in the
+            %          CoppeliaSim scene.
+            %
+            % Example: 
+            %     cs = DQ_CoppeliaSimInterfaceZMQ();
+            %     cs.connect;
+            %     robot_coppeliasim = DQ_SerialCoppeliaSimRobotZMQ("/LBR4p", cs);
+            %     q = zeros(7, 1);
+            %     robot_coppeliasim.set_configuration(q);
+            %     
+            %     Note that this calls "set_joint_positions" in
+            %     DQ_CoppeliaSimInterfaceZMQ, meaning that it requires a
+            %     dynamics disabled scene.
+
+            arguments 
+                obj (1,1) DQ_SerialCoppeliaSimRobotZMQ
+                q (1,:) {mustBeNumeric}
+            end
+
+            obj.coppeliasim_interface_.set_joint_positions( ...
+                obj.joint_names_, q);
+        end
+
+        function set_target_configuration(obj, q)
+            % This method sets the target joint configurations for the robot
+            % in the CoppeliaSim scene.
+            % Usage:
+            %     set_target_configuration(q);  
+            %          q: The target joint configurations for the robot in
+            %          the CoppeliaSim scene.
+            %
+            % Example: 
+            %     cs = DQ_CoppeliaSimInterfaceZMQ();
+            %     cs.connect;
+            %     robot_coppeliasim = DQ_SerialCoppeliaSimRobotZMQ("/LBR4p", cs);
+            %     q = zeros(7, 1);
+            %     robot_coppeliasim.set_target_configuration(q);
+            %     
+            %     Note that this calls "set_joint_target_positions" in
+            %     DQ_CoppeliaSimInterfaceZMQ, meaning that it requires a
+            %     dynamics dynamics-enabled scene and joints in dynamic
+            %     mode with position control mode.
+
+            arguments 
+                obj (1,1) DQ_SerialCoppeliaSimRobotZMQ
+                q (1,:) {mustBeNumeric}
+            end
+
+            obj.coppeliasim_interface_.set_joint_target_positions( ...
+                obj.joint_names_, q);
+        end
+
+        function q = get_configuration(obj)
+            % This method gets the joint configurations of the robot in the
+            % CoppeliaSim scene.
+            % Usage:
+            %     get_configuration();  
+            %
+            % Example: 
+            %     cs = DQ_CoppeliaSimInterfaceZMQ();
+            %     cs.connect;
+            %     robot_coppeliasim = DQ_SerialCoppeliaSimRobotZMQ("/LBR4p", cs);
+            %     q = robot_coppeliasim.get_configuration;
+
+            arguments 
+                obj (1,1) DQ_SerialCoppeliaSimRobotZMQ
+            end
+
+            q = obj.coppeliasim_interface_.get_joint_positions( ...
+                    obj.joint_names_);
+        end
+
+        function set_target_configuration_velocities(obj, dq)
+            % This method sets the target joint configuration velocities
+            % for the robot in the CoppeliaSim scene.
+            % Usage:
+            %     set_target_configuration_velocities(dq);  
+            %          dq: The target joint configuration velocities for
+            %          the robot in the CoppeliaSim scene.
+            %
+            % Example: 
+            %     cs = DQ_CoppeliaSimInterfaceZMQ();
+            %     cs.connect;
+            %     robot_coppeliasim = DQ_SerialCoppeliaSimRobotZMQ("/LBR4p", cs);
+            %     dq = zeros(7, 1);
+            %     robot_coppeliasim.set_target_configuration_velocities(dq);
+            %     
+            %     Note that this calls "set_joint_target_velocities" in
+            %     DQ_CoppeliaSimInterfaceZMQ, meaning that it requires a
+            %     dynamics dynamics-enabled scene and joints in dynamic
+            %     mode with velocity control mode.
+
+            arguments 
+                obj (1,1) DQ_SerialCoppeliaSimRobotZMQ
+                dq (1,:) {mustBeNumeric}
+            end
+
+            obj.coppeliasim_interface_.set_joint_target_velocities( ...
+                obj.joint_names_, dq);
+        end
+
+        function dq = get_configuration_velocities(obj)
+            % This method gets the joint configuration velocities of the
+            % robot in the CoppeliaSim scene.
+            % Usage:
+            %     get_configuration_velocities();  
+            %
+            % Example: 
+            %     cs = DQ_CoppeliaSimInterfaceZMQ();
+            %     cs.connect;
+            %     robot_coppeliasim = DQ_SerialCoppeliaSimRobotZMQ("/LBR4p", cs);
+            %     dq = robot_coppeliasim.get_configuration_velocities;
+
+            arguments 
+                obj (1,1) DQ_SerialCoppeliaSimRobotZMQ
+            end
+
+            dq = obj.coppeliasim_interface_.get_joint_velocities( ...
+                    obj.joint_names_);
+        end
+
+        function set_target_configuration_forces(obj, tau)
+            % This method sets the target joint configuration forces for
+            % the robot in the CoppeliaSim scene.
+            % Usage:
+            %     set_target_configuration_forces(tau);  
+            %          tau: The target joint configuration forces for the
+            %          robot in the CoppeliaSim scene.
+            %
+            % Example: 
+            %     cs = DQ_CoppeliaSimInterfaceZMQ();
+            %     cs.connect;
+            %     robot_coppeliasim = DQ_SerialCoppeliaSimRobotZMQ("/LBR4p", cs);
+            %     tau = zeros(7, 1);
+            %     robot_coppeliasim.set_target_configuration_forces(tau);
+            %     
+            %     Note that this calls "set_joint_target_forces" in
+            %     DQ_CoppeliaSimInterfaceZMQ, meaning that it requires a
+            %     dynamics dynamics-enabled scene and joints in dynamic
+            %     mode with force control mode.
+
+            arguments 
+                obj (1,1) DQ_SerialCoppeliaSimRobotZMQ
+                tau (1,:) {mustBeNumeric}
+            end
+
+            obj.coppeliasim_interface_.set_joint_target_forces( ...
+                obj.joint_names_, tau);
+        end
+
+        function tau = get_configuration_forces(obj)
+            % This method gets the joint configuration forces of the
+            % robot in the CoppeliaSim scene.
+            % Usage:
+            %     get_configuration_forces();  
+            %
+            % Example: 
+            %     cs = DQ_CoppeliaSimInterfaceZMQ();
+            %     cs.connect;
+            %     robot_coppeliasim = DQ_SerialCoppeliaSimRobotZMQ("/LBR4p", cs);
+            %     tau = robot_coppeliasim.get_configuration_forces;
+
+            arguments 
+                obj (1,1) DQ_SerialCoppeliaSimRobotZMQ
+            end
+
+            tau = obj.coppeliasim_interface_.get_joint_forces( ...
+                    obj.joint_names_);
+        end
+    end
+end

--- a/interfaces/coppeliasim/robots/LBR4pCoppeliaSimRobotZMQ.m
+++ b/interfaces/coppeliasim/robots/LBR4pCoppeliaSimRobotZMQ.m
@@ -44,7 +44,7 @@
 %    the second one "/LBR4p[1]". A third robot will be named "/LBR4p[2]",
 %    and so on.
 
-classdef LBR4pCoppeliaSimRobotZMQ < DQ_SerialCoppeliaSimRobotZMQ
+classdef LBR4pCoppeliaSimRobotZMQ < DQ_CoppeliaSimRobotZMQ
     methods
         function obj = LBR4pCoppeliaSimRobotZMQ(robot_name, coppeliasim_interface)
             % This method constructs an instance of a KUKA LBR4+ robot.
@@ -72,7 +72,7 @@ classdef LBR4pCoppeliaSimRobotZMQ < DQ_SerialCoppeliaSimRobotZMQ
                 coppeliasim_interface (1,1) DQ_CoppeliaSimInterfaceZMQ
             end
 
-            obj@DQ_SerialCoppeliaSimRobotZMQ(robot_name, ...
+            obj@DQ_CoppeliaSimRobotZMQ(robot_name, ...
                 coppeliasim_interface);
         end
 

--- a/interfaces/coppeliasim/robots/LBR4pCoppeliaSimRobotZMQ.m
+++ b/interfaces/coppeliasim/robots/LBR4pCoppeliaSimRobotZMQ.m
@@ -1,0 +1,119 @@
+% (C) Copyright 2011-2025 DQ Robotics Developers
+% 
+% This file is part of DQ Robotics.
+% 
+%     DQ Robotics is free software: you can redistribute it and/or modify
+%     it under the terms of the GNU Lesser General Public License as published by
+%     the Free Software Foundation, either version 3 of the License, or
+%     (at your option) any later version.
+% 
+%     DQ Robotics is distributed in the hope that it will be useful,
+%     but WITHOUT ANY WARRANTY; without even the implied warranty of
+%     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%     GNU Lesser General Public License for more details.
+% 
+%     You should have received a copy of the GNU Lesser General Public License
+%     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
+% 
+% DQ Robotics website: dqrobotics.github.io
+% 
+% Contributors:
+% 
+%    1. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
+%         - Responsible for the original implementation
+%
+%
+% LBR4pCoppeliaSimRobotZMQ - Concrete class to interface with the "KUKA
+% LBR4+" robot in CoppeliaSim.
+%
+% Usage:
+%
+%   1. Drag-and-drop a "KUKA LBR4+" robot to a CoppeliaSim scene.
+%
+%   2. Run
+%       >> cs = DQ_CoppeliaSimInterfaceZMQ();
+%       >> cs.connect;
+%       >> robot_coppeliasim = LBR4pVrepRobot("/LBR4p", cs);
+%       >> cs.start_simulation();
+%       >> robot_coppeliasim.get_configuration();
+%       >> pause(1);
+%       >> cs.stop_simulation();
+%    Note that the name of the robot should be EXACTLY the same as in
+%    CoppeliaSim. For instance, if you drag-and-drop a second robot to the
+%    scene, CoppeliaSim will rename the first robot to "/LBR4p[0]" and name
+%    the second one "/LBR4p[1]". A third robot will be named "/LBR4p[2]",
+%    and so on.
+
+classdef LBR4pCoppeliaSimRobotZMQ < DQ_SerialCoppeliaSimRobotZMQ
+    methods
+        function obj = LBR4pCoppeliaSimRobotZMQ(robot_name, coppeliasim_interface)
+            % This method constructs an instance of a KUKA LBR4+ robot.
+            % Usage:
+            %     LBR4pCoppeliaSimRobotZMQ(robot_name, coppeliasim_interface)
+            %          robot_name: The name of the robot in the CoppeliaSim
+            %          scene.
+            %          coppeliasim_interface: The DQ_CoppeliaSimInterfaceZMQ
+            %          object connected to the CoppeliaSim scene.
+            %
+            % Example: 
+            %      cs = DQ_CoppeliaSimInterfaceZMQ();
+            %      cs.connect;
+            %      robot_coppeliasim = LBR4pCoppeliaSimRobotZMQ("/LBR4p", cs);
+            %     
+            %    Note that the name of the robot should be EXACTLY the same
+            %    as in CoppeliaSim. For instance, if you drag-and-drop a
+            %    second robot to the scene, CoppeliaSim will rename the
+            %    first robot to "/LBR4p[0]" and name the second one
+            %    "/LBR4p[1]". A third robot will be named "/LBR4p[2]", and
+            %    so on.
+
+            arguments 
+                robot_name (1,:) {mustBeText}
+                coppeliasim_interface (1,1) DQ_CoppeliaSimInterfaceZMQ
+            end
+
+            obj@DQ_SerialCoppeliaSimRobotZMQ(robot_name, ...
+                coppeliasim_interface);
+        end
+
+        function kin = kinematics(obj)
+            % This method constructs an instance of a DQ_SerialManipulatorDH.
+            % Usage:
+            %     kinematics();
+            %
+            % Example: 
+            %      cs = DQ_CoppeliaSimInterfaceZMQ();
+            %      cs.connect;
+            %      robot_coppeliasim = LBR4pCoppeliaSimRobotZMQ("/LBR4p", cs);
+            %      robot_kinematics = robot_coppeliasim.kinematics();
+
+            arguments 
+                obj (1,1) LBR4pCoppeliaSimRobotZMQ
+            end
+
+            LBR4p_DH_theta = [0, 0, 0, 0, 0, 0, 0];
+            LBR4p_DH_d = [0.200, 0, 0.4, 0, 0.39, 0, 0];
+            LBR4p_DH_a = [0, 0, 0, 0, 0, 0, 0];
+            LBR4p_DH_alpha = [pi/2, -pi/2, pi/2, -pi/2, pi/2, -pi/2, 0];
+            LBR4p_DH_type = double(repmat( ...
+                DQ_SerialManipulatorDH.JOINT_ROTATIONAL, 1, 7));
+            LBR4p_DH_matrix = [LBR4p_DH_theta;
+                               LBR4p_DH_d;
+                               LBR4p_DH_a;
+                               LBR4p_DH_alpha
+                               LBR4p_DH_type];
+            
+            kin = DQ_SerialManipulatorDH(LBR4p_DH_matrix, 'standard');
+            
+            % Set the reference frames
+            kin.set_reference_frame( ...
+                obj.coppeliasim_interface_.get_object_pose( ...
+                    obj.base_frame_name_));
+            kin.set_base_frame(obj.coppeliasim_interface_.get_object_pose( ...
+                obj.base_frame_name_));
+
+            % Set the end-effector
+            kin.set_effector(1 + 0.5*DQ.E*DQ.k*0.07);
+        end
+    end
+end

--- a/interfaces/coppeliasim/robots/YouBotCoppeliaSimRobotZMQ.m
+++ b/interfaces/coppeliasim/robots/YouBotCoppeliaSimRobotZMQ.m
@@ -1,0 +1,215 @@
+% (C) Copyright 2011-2025 DQ Robotics Developers
+% 
+% This file is part of DQ Robotics.
+% 
+%     DQ Robotics is free software: you can redistribute it and/or modify
+%     it under the terms of the GNU Lesser General Public License as published by
+%     the Free Software Foundation, either version 3 of the License, or
+%     (at your option) any later version.
+% 
+%     DQ Robotics is distributed in the hope that it will be useful,
+%     but WITHOUT ANY WARRANTY; without even the implied warranty of
+%     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%     GNU Lesser General Public License for more details.
+% 
+%     You should have received a copy of the GNU Lesser General Public License
+%     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
+% 
+% DQ Robotics website: dqrobotics.github.io
+% 
+% Contributors:
+% 
+%    1. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
+%         - Responsible for the original implementation
+%
+%
+% YouBotCoppeliaSimRobotZMQ - Concrete class to interface with the "youBot"
+% robot in CoppeliaSim.
+%
+% Usage:
+%
+%   1. Drag-and-drop a "youBot" robot to a CoppeliaSim scene.
+%
+%   2. Run
+%       >> cs = DQ_CoppeliaSimInterfaceZMQ();
+%       >> cs.connect;
+%       >> robot_coppeliasim = YouBotCoppeliaSimRobotZMQ("/youBot", cs);
+%       >> cs.start_simulation();
+%       >> robot_coppeliasim.get_configuration();
+%       >> pause(1);
+%       >> cs.stop_simulation();
+%    Note that the name of the robot should be EXACTLY the same as in
+%    CoppeliaSim. For instance, if you drag-and-drop a second robot to the
+%    scene, CoppeliaSim will rename the first robot to "/youBot[0]" and
+%    name the second one "/youBot[1]". A third robot will be named
+%    "/youBot[2]", and so on.
+
+classdef YouBotCoppeliaSimRobotZMQ < DQ_SerialCoppeliaSimRobotZMQ
+    properties (Constant)
+        adjust_ = ((cos(pi/2) + DQ.i*sin(pi/2))*(cos(pi/4) + ...
+                        DQ.j*sin(pi/4)))*(1 + 0.5*DQ.E* - 0.1*DQ.k);
+    end
+
+    methods
+        function obj = YouBotCoppeliaSimRobotZMQ(robot_name, coppeliasim_interface)
+            % This method constructs an instance of a youBot robot.
+            % Usage:
+            %     YouBotCoppeliaSimRobotZMQ(robot_name, coppeliasim_interface)
+            %          robot_name: The name of the robot in the CoppeliaSim
+            %          scene.
+            %          coppeliasim_interface: The DQ_CoppeliaSimInterfaceZMQ
+            %          object connected to the CoppeliaSim scene.
+            %
+            % Example: 
+            %      cs = DQ_CoppeliaSimInterfaceZMQ();
+            %      cs.connect;
+            %      robot_coppeliasim = YouBotCoppeliaSimRobotZMQ("/youBot", cs);
+            %     
+            %    Note that the name of the robot should be EXACTLY the same
+            %    as in CoppeliaSim. For instance, if you drag-and-drop a
+            %    second robot to the scene, CoppeliaSim will rename the
+            %    first robot to "/youBot[0]" and name the second one
+            %    "/youBot[1]". A third robot will be named "/youBot[2]",
+            %    and so on.
+
+            arguments 
+                robot_name (1,:) {mustBeText}
+                coppeliasim_interface (1,1) DQ_CoppeliaSimInterfaceZMQ
+            end
+
+            obj@DQ_SerialCoppeliaSimRobotZMQ(robot_name, ...
+                                          coppeliasim_interface);
+
+            % Fix the base name because youBot is a mobile manipulator
+            obj.base_frame_name_ = robot_name;
+
+            % Fix the joint names set by DQ_SerialCoppeliaSimRobot because
+            % youBot does not follow the standard naming convention in
+            % CoppeliaSim
+            auto_joint_names = obj.joint_names_;
+            obj.joint_names_ = cell(5,1);
+            [obj.joint_names_{:}] = deal(auto_joint_names{4}, ...
+                                         auto_joint_names{9}, ...
+                                         auto_joint_names{12:14});
+        end
+
+        function set_configuration(obj, q)
+            % This method sets the joint configurations of the robot in the
+            % CoppeliaSim scene.
+            % Usage:
+            %     set_configuration(q);  
+            %          q: The joint configurations for the robot in the
+            %          CoppeliaSim scene.
+            %
+            % Example: 
+            %     cs = DQ_CoppeliaSimInterfaceZMQ();
+            %     cs.connect;
+            %     robot_coppeliasim = YouBotCoppeliaSimRobotZMQ("/youBot", cs);
+            %     q = zeros(8, 1);
+            %     robot_coppeliasim.set_configuration(q);
+            %     
+            %     Note that this calls "set_joint_positions" in
+            %     DQ_CoppeliaSimInterfaceZMQ, meaning that it requires a
+            %     dynamics disabled scene.
+
+            arguments 
+                obj (1,1) YouBotCoppeliaSimRobotZMQ
+                q (1,:) {mustBeNumeric}
+            end
+
+            % Calculate the base's pose from its configuration
+            x = q(1);
+            y = q(2);
+            phi = q(3);
+            
+            r = cos(phi/2.0)+DQ.k*sin(phi/2.0);
+            p = x*DQ.i + y*DQ.j;
+            pose = (1 + DQ.E*0.5*p)*r;
+
+            % Set the base's pose and the arm's configuration in
+            % CoppeliaSim
+            obj.coppeliasim_interface_.set_object_pose( ...
+                obj.base_frame_name_, pose*(obj.adjust_'));
+            obj.coppeliasim_interface_.set_joint_positions( ...
+                obj.joint_names_, q(4:8));
+        end
+
+        function q = get_configuration(obj)
+            % This method gets the joint configurations of the robot in the
+            % CoppeliaSim scene.
+            % Usage:
+            %     get_configuration();  
+            %
+            % Example: 
+            %     cs = DQ_CoppeliaSimInterfaceZMQ();
+            %     cs.connect;
+            %     robot_coppeliasim = YouBotCoppeliaSimRobotZMQ("/youBot", cs);
+            %     q = robot_coppeliasim.get_configuration;
+
+            arguments 
+                obj (1,1) YouBotCoppeliaSimRobotZMQ
+            end
+
+            % Get the base's pose from CoppeliaSim
+            base_pose = obj.coppeliasim_interface_.get_object_pose( ...
+                obj.base_frame_name_)*obj.adjust_;
+            base_translation = vec3(translation(base_pose));
+            base_phi = rotation_angle(rotation(base_pose));
+
+            % Get the arm's configuration from CoppeliaSim
+            base_arm_q = obj.coppeliasim_interface_.get_joint_positions( ...
+                obj.joint_names_);
+            
+            % Concatenate the base's pose and the arm's configuration
+            q = [base_translation(1);
+                 base_translation(2);
+                 base_phi;
+                 base_arm_q];
+        end
+
+        function kin = kinematics(~)
+            % This method constructs an instance of a DQ_WholeBody.
+            % Usage:
+            %     kinematics();
+            %
+            % Example: 
+            %      cs = DQ_CoppeliaSimInterfaceZMQ();
+            %      cs.connect;
+            %      robot_coppeliasim = YouBotCoppeliaSimRobotZMQ("/youBot", cs);
+            %      robot_kinematics = robot_coppeliasim.kinematics();
+            
+            include_namespace_dq
+
+            % The DH parameters and other geometric parameters are based on
+            % Kuka's documentation:
+            %   http://www.youbot-store.com/wiki/index.php/YouBot_Detailed_Specifications
+            %   https://www.generationrobots.com/img/Kuka-YouBot-Technical-Specs.pdf
+
+            arm_DH_theta = [0, pi/2, 0, pi/2, 0];
+            arm_DH_d = [0.147, 0, 0, 0, 0.218];
+            arm_DH_a = [0.033, 0.155, 0.135, 0, 0];
+            arm_DH_alpha = [pi/2, 0, 0, pi/2, 0];
+            arm_DH_type = double(repmat( ...
+                DQ_SerialManipulatorDH.JOINT_ROTATIONAL, 1, 5));
+            arm_DH_matrix = [arm_DH_theta;
+                             arm_DH_d;
+                             arm_DH_a;
+                             arm_DH_alpha;
+                             arm_DH_type];
+            
+            arm =  DQ_SerialManipulatorDH(arm_DH_matrix, 'standard');
+            base = DQ_HolonomicBase();
+            
+            % Set the base's frame displacement
+            x_bm = 1 + E_*0.5*(0.165*i_ + 0.11*k_);            
+            base.set_frame_displacement(x_bm);
+            
+            % Create a DQ_WholeBody object
+            kin = DQ_WholeBody(base);
+            kin.add(arm);
+            
+            % Set the end-effector
+            kin.set_effector(1 + E_*0.5*0.3*k_);
+        end
+    end
+end

--- a/interfaces/coppeliasim/robots/YouBotCoppeliaSimRobotZMQ.m
+++ b/interfaces/coppeliasim/robots/YouBotCoppeliaSimRobotZMQ.m
@@ -44,7 +44,7 @@
 %    name the second one "/youBot[1]". A third robot will be named
 %    "/youBot[2]", and so on.
 
-classdef YouBotCoppeliaSimRobotZMQ < DQ_SerialCoppeliaSimRobotZMQ
+classdef YouBotCoppeliaSimRobotZMQ < DQ_CoppeliaSimRobotZMQ
     properties (Constant)
         adjust_ = ((cos(pi/2) + DQ.i*sin(pi/2))*(cos(pi/4) + ...
                         DQ.j*sin(pi/4)))*(1 + 0.5*DQ.E* - 0.1*DQ.k);
@@ -77,7 +77,7 @@ classdef YouBotCoppeliaSimRobotZMQ < DQ_SerialCoppeliaSimRobotZMQ
                 coppeliasim_interface (1,1) DQ_CoppeliaSimInterfaceZMQ
             end
 
-            obj@DQ_SerialCoppeliaSimRobotZMQ(robot_name, ...
+            obj@DQ_CoppeliaSimRobotZMQ(robot_name, ...
                                           coppeliasim_interface);
 
             % Fix the base name because youBot is a mobile manipulator


### PR DESCRIPTION
Dear @dqrobotics/developers,

This PR implements the classes `DQ_SerialCoppeliaSimRobotZMQ`, `LBR4pCoppeliaSimRobotZMQ`, and `YouBotCoppeliaSimRobotZMQ`. They are the ZMQ equivalent of the old V-REP interface classes [DQ_SerialVrepRobot](https://github.com/dqrobotics/matlab-interface-vrep/blob/main/interfaces/vrep/DQ_SerialVrepRobot.m), [LBR4pVrepRobot](https://github.com/dqrobotics/matlab-interface-vrep/blob/main/interfaces/vrep/robots/LBR4pVrepRobot.m), and [YouBotVrepRobot](https://github.com/dqrobotics/matlab-interface-vrep/blob/main/interfaces/vrep/robots/YouBotVrepRobot.m), respectively.

`DQ_SerialCoppeliaSimRobotZMQ` inherits from [DQ_CoppeliaSimRobot](https://github.com/dqrobotics/matlab-interface-coppeliasim/blob/main/interfaces/coppeliasim/DQ_CoppeliaSimRobot.m) and implements all the abstract methods required by it, whereas `LBR4pCoppeliaSimRobotZMQ` and `YouBotCoppeliaSimRobotZMQ` are concrete instantiations of `DQ_SerialCoppeliaSimRobotZMQ` to CoppeliaSim's KUKA LBR4+ and youBot robots, respectively.

To test my implementations, I updated the old [simulation-ram-paper](https://github.com/dqrobotics/matlab-examples/tree/ram-paper-updated/vrep/simulation-ram-paper) to work with the new ZMQ interface. This simulation is available in [14](https://github.com/dqrobotics/matlab-examples/pull/14).

Please let me know what you think of it.

Kind regards,
Frederico